### PR TITLE
fixed a broken link to the NVM repo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ```fish
 $ omf install nvm
 ```
-**NB** You have to install **nvm** itself separately (the [curl method](https://github.com/creationix/nvm/blob/master/README.markdown#install-script) works fine under Fish too).
+**NB** You have to install **nvm** itself separately (the [curl method](https://github.com/creationix/nvm/blob/master/README.md#install-script) works fine under Fish too).
 
 
 ## Usage


### PR DESCRIPTION
The link to the NVM readme was broken because they changed the file extension from .markdown to .md.