### PR TITLE
Add --no-use to nvm.sh sourceing

### DIFF
--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -5,7 +5,7 @@ function nvm -d "Node version manager"
       return 1
     end
 
-    fenv source $nvm_prefix/nvm.sh\; nvm $argv
+    fenv source $nvm_prefix/nvm.sh --no-use ';' nvm $argv
   else
     echo "You need to install nvm itself (see https://github.com/creationix/nvm#installation)"
     return 1

--- a/test/cases/104_switch_node_versions.fish
+++ b/test/cases/104_switch_node_versions.fish
@@ -1,2 +1,4 @@
-it_should "install node v4" "nvm install v4; and nvm use v4"
-it_should "have switched to node v4" "test (node --version | cut -c2) = 4"
+it_should "install node version" "nvm install v4; nvm install v5"
+it_should "set default version" "nvm alias default v4"
+it_should "switch node version" "nvm use v5; test (node --version | cut -c2) = 5"
+it_should "return the correct node version" "test (node --version = nvm version)"


### PR DESCRIPTION
Option `--no-use` of `nvm.sh` prevents it from loading the default node version. This ensures the already loaded version (ie. from .nvmrc file) remains active.

```bash
nvm install v6
nvm install v8
nvm alias default v8
nvm use v6
node --version # v6...
nvm version # see below
```

**Expected:** v6...
**Actual:** v8...