### PR TITLE
Fix error after upgrade to fish 3.1.0 on Ubuntu

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -7,7 +7,7 @@ function init -a path --on-event init_nvm
       and test -e (brew --prefix)/Cellar/nvm;
         and set -g nvm_prefix (brew --prefix nvm)
 
-    fenv source $nvm_prefix/nvm.sh >/dev/null ^&1
+    fenv source $nvm_prefix/nvm.sh >/dev/null 2>&1
   end
 
 end


### PR DESCRIPTION
`^` as a redirect to stderr was removed from fish 3.0.0. Weird that it only happened on Ubuntu after upgrading to 3.1.0...

Fixes #16.