### PR TITLE
Keep nvm_prefix if set

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Refresh your shell and you are good to go!
 refresh
 ```
 
+If you have installed nvm using a package manager you need to specify where is been installed, add the following line to  your `~/.config/fish/config.fish`
+
+```fish
+set -g nvm_prefix /path/to/nvm
+```
+In this case, you don't need to set the `NVM_DIR` where the node versions will be installed, by default will be `~/.nvm`, but you can customize it if you want.
+
+**Note** [Brew](https://brew.sh/) users don't have set up it, the plugin auto-detects it and set up the variable accordingly.
+
 # License
 
 [MIT][mit] © [Derek Willian Stavis][author] et [al][contributors]

--- a/init.fish
+++ b/init.fish
@@ -1,7 +1,7 @@
 function init -a path --on-event init_nvm
   if type -q fenv
     set -q NVM_DIR; or set -gx NVM_DIR ~/.nvm
-    set -g nvm_prefix $NVM_DIR
+    set -q nvm_prefix; or set -g nvm_prefix $NVM_DIR
 
     type -q brew;
       and test -e (brew --prefix)/Cellar/nvm;


### PR DESCRIPTION
Currently, I was dealing with nvm on my Arch Linux installed from [AUR](https://aur.archlinux.org/packages/nvm). The package manager install it in `/usr/share/nvm/`

The plugin didn't work well, setting `NVM_DIR` ended up nvm trying to download and install nvm version in `/usr/share/nvm/`.

Looking in the code, I discovered that there's a patch for brew users that sets the `nvm_prefix` for them. So I'm proposing on this patch allow the users to set their own `nvm_prefix` for similar cases.

Hope this helps